### PR TITLE
fix: test_case.json

### DIFF
--- a/sentiment-analysis/tests/test_case.json
+++ b/sentiment-analysis/tests/test_case.json
@@ -1,4 +1,4 @@
-{
+[{
     "scheme": "CKKS",
     "significant_slots_number": 3,
     "runs": [
@@ -783,4 +783,4 @@
             ]
         }
     ]
-}
+}]


### PR DESCRIPTION
The data format of a test_case.json seem to expect a list of dicts.
The current format is a single dict. It lead to the following issue when running locally:


```
2025-05-29 14:29:02,501 [MainThread  ] [ERROR]  'str' object has no attribute 'get'
Traceback (most recent call last):
  File "user_wb_validator.py", line 130, in run_white_box
AttributeError: 'str' object has no attribute 'get'
```